### PR TITLE
Implements CustomAttributeRegistry::get

### DIFF
--- a/test/all.html
+++ b/test/all.html
@@ -25,6 +25,7 @@
   </div>
   <div class="tests">
     <iframe src="./change.html"></iframe>
+    <iframe src="./get.html"></iframe>
   </div>
 </body>
 </html>

--- a/test/get.html
+++ b/test/get.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html>
+<head>
+  <title>get() tests</title>
+
+  <script src="../node_modules/webcomponents.js/webcomponents-lite.min.js" defer></script>
+  <script src="../attr.js" defer></script>
+  <link rel="import" href="../node_modules/mocha-test/mocha-test.html" defer>
+</head>
+<body>
+<div id="fixture"></div>
+<mocha-test>
+<template>
+<script>
+  describe('get()', function(){
+    function later(fn){
+      setTimeout(fn, 0);
+    }
+
+    afterEach(function(){
+      fixture.innerHTML = '';
+    });
+
+    it('gets the attribute instance', function(done){
+      class Foobar {}
+      customAttributes.define('foo-bar', Foobar);
+
+      var el = document.createElement('span');
+      el.setAttribute('foo-bar', 'baz');
+      fixture.appendChild(el);
+
+      later(function(){
+        var fooBar = customAttributes.get(el, 'foo-bar');
+        assert.ok(fooBar instanceof Foobar);
+        done();
+      });
+    });
+
+    it('allows passing more complex data types', function(done){
+      class Foobar {
+        set baz(val) {
+          assert.equal(val, 'hello world');
+          done();
+        }
+      }
+      customAttributes.define('foo-bar', Foobar);
+
+      var el = document.createElement('span');
+      el.setAttribute('foo-bar', 'bam');
+      fixture.appendChild(el);
+
+      later(function(){
+        var fooBar = customAttributes.get(el, 'foo-bar');
+        fooBar.baz = 'hello world';
+      });
+    });
+  });
+</script>
+</template>
+</mocha-test>
+</body>
+</html>


### PR DESCRIPTION
This implements `customAttributes.get(el, attrName)` as a way to get an
instance of an attribute. This is useful when you want to pass more
complex data types to an instance.
