### PR TITLE
Adds support for multiple registries. Fixes #3

### DIFF
--- a/attr.js
+++ b/attr.js
@@ -30,8 +30,7 @@ class CustomAttributeRegistry {
 
   _observe(){
     var customAttributes = this;
-    var document = this.ownerDocument;
-    var root = document.documentElement;
+    var root = this.ownerDocument;
     var downgrade = this._downgrade.bind(this);
     var upgrade = this._upgradeElement.bind(this);
 

--- a/attr.js
+++ b/attr.js
@@ -129,5 +129,6 @@ class CustomAttributeRegistry {
   }
 }
 
+window.CustomAttributeRegistry = CustomAttributeRegistry;
 window.customAttributes = new CustomAttributeRegistry(document);
 })();


### PR DESCRIPTION
Uses the `document` node over `document.documentElement` so as to support arbitrary Node's being passed in for observation. This is intended for observing Shadow Trees.

Also add `CustomAttributeRegistry` as a global on `window` to allow creating extra registries for other documents / trees e.g. Shadow Trees.

Fixes #3 