### PR TITLE
Add a build that allows for ES module use

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+.PHONY: build all
+
+all: build
+
+build:
+	node_modules/.bin/rollup -o attr.js -f iife global.js

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Add as a script tag:
 Or import as an ES module:
 
 ```js
-import { customAttributes } from 'custom-attributes';
+import customAttributes from 'custom-attributes';
 ```
 
 Or you can just import the CustomAttributeRegistry and create your own instance:

--- a/README.md
+++ b/README.md
@@ -11,8 +11,24 @@ Define custom attributes in the same way you can define custom elements, which a
 npm install custom-attributes --save
 ```
 
+Add as a script tag:
+
 ```html
 <script src="node_modules/custom-attributes/attr.js" defer></script>
+```
+
+Or import as an ES module:
+
+```js
+import { customAttributes } from 'custom-attributes';
+```
+
+Or you can just import the CustomAttributeRegistry and create your own instance:
+
+```js
+import CustomAttributeRegistry from 'custom-attributes/registry';
+
+const customAttributes = new CustomAttributeRegistry(document);
 ```
 
 ## Example

--- a/attr.js
+++ b/attr.js
@@ -1,6 +1,8 @@
 (function () {
 'use strict';
 
+var forEach = Array.prototype.forEach;
+
 class CustomAttributeRegistry {
   constructor(ownerDocument){
     if(!ownerDocument) {

--- a/global.js
+++ b/global.js
@@ -1,4 +1,4 @@
-import { customAttributes, CustomAttributeRegistry } from './index.js';
+import customAttributes, { CustomAttributeRegistry } from './index.js';
 
 window.customAttributes = customAttributes;
 window.CustomAttributeRegistry = CustomAttributeRegistry;

--- a/global.js
+++ b/global.js
@@ -1,0 +1,4 @@
+import { customAttributes, CustomAttributeRegistry } from './index.js';
+
+window.customAttributes = customAttributes;
+window.CustomAttributeRegistry = CustomAttributeRegistry;

--- a/index.js
+++ b/index.js
@@ -1,0 +1,5 @@
+import CustomAttributeRegistry from './registry.js';
+
+var customAttributes = new CustomAttributeRegistry(document);
+
+export { customAttributes, CustomAttributeRegistry }

--- a/index.js
+++ b/index.js
@@ -2,4 +2,4 @@ import CustomAttributeRegistry from './registry.js';
 
 var customAttributes = new CustomAttributeRegistry(document);
 
-export { customAttributes, CustomAttributeRegistry }
+export { customAttributes as default, CustomAttributeRegistry }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "custom-attributes",
   "version": "1.0.1",
   "description": "Custom attributes, like custom elements, but for attributes",
-  "main": "attr.js",
+  "main": "index.js",
   "directories": {
     "test": "test"
   },
@@ -29,6 +29,7 @@
   "homepage": "https://github.com/matthewp/custom-attributes#readme",
   "devDependencies": {
     "mocha-test": "^1.0.3",
+    "rollup": "^0.41.4",
     "testee": "^0.3.0",
     "webcomponents.js": "^0.7.22"
   }

--- a/registry.js
+++ b/registry.js
@@ -1,3 +1,5 @@
+var forEach = Array.prototype.forEach;
+
 class CustomAttributeRegistry {
   constructor(ownerDocument){
     if(!ownerDocument) {

--- a/registry.js
+++ b/registry.js
@@ -1,6 +1,3 @@
-(function () {
-'use strict';
-
 class CustomAttributeRegistry {
   constructor(ownerDocument){
     if(!ownerDocument) {
@@ -134,9 +131,4 @@ class CustomAttributeRegistry {
   }
 }
 
-var customAttributes = new CustomAttributeRegistry(document);
-
-window.customAttributes = customAttributes;
-window.CustomAttributeRegistry = CustomAttributeRegistry;
-
-}());
+export default CustomAttributeRegistry;


### PR DESCRIPTION
This adds a build so that custom-attributes can be used as an ES module.

```js
import { customAttributes, CustomAttributeRegistry } from
'custom-attributes';
```

The above imports each, without anything being set on the `window`. If
you just want the registry you can do:

```js
import CustomAttributeRegistry from 'custom-attributes/registry';
```

and create your own instance.

The same script tag will still work which sets the global:

```html
<script src="./node_modules/custom-attributes/attr.js"></script>
```

Closes #7 

cc @bedeoverend 