### PR TITLE
Support Edge and IE11

### DIFF
--- a/attr.js
+++ b/attr.js
@@ -64,6 +64,8 @@ class CustomAttributeRegistry {
     document = document || this.ownerDocument;
 
     var matches = document.querySelectorAll("[" + attrName + "]");
+
+    // Use a forEach as Edge doesn't support for...of on a NodeList
     forEach.call(matches, function(match) {
       this._found(attrName, match);
     }, this);
@@ -79,20 +81,20 @@ class CustomAttributeRegistry {
       }
     }, this);
 
-    for(var attr of this._attrMap.keys()) {
+    this._attrMap.forEach(function(constructor, attr) {
       this._upgradeAttr(attr, element);
-    }
+    }, this);
   }
 
   _downgrade(element) {
     var map = this._elementMap.get(element);
     if(!map) return;
 
-    for(var inst of map.values()) {
-      if(inst.disconnectedCallback) {
+    map.forEach(function(inst) {
+      if (inst.disconnectedCallback) {
         inst.disconnectedCallback();
       }
-    }
+    }, this);
 
     this._elementMap.delete(element);
   }

--- a/attr.js
+++ b/attr.js
@@ -64,9 +64,9 @@ class CustomAttributeRegistry {
     document = document || this.ownerDocument;
 
     var matches = document.querySelectorAll("[" + attrName + "]");
-    for(var match of matches) {
+    forEach.call(matches, function(match) {
       this._found(attrName, match);
-    }
+    }, this);
   }
 
   _upgradeElement(element) {
@@ -78,7 +78,6 @@ class CustomAttributeRegistry {
         this._found(attr.name, element);
       }
     }, this);
-
 
     for(var attr of this._attrMap.keys()) {
       this._upgradeAttr(attr, element);

--- a/registry.js
+++ b/registry.js
@@ -78,20 +78,20 @@ class CustomAttributeRegistry {
       }
     }, this);
 
-    for(var attr of this._attrMap.keys()) {
+    this._attrMap.forEach(function(constructor, attr) {
       this._upgradeAttr(attr, element);
-    }
+    }, this);
   }
 
   _downgrade(element) {
     var map = this._elementMap.get(element);
     if(!map) return;
 
-    for(var inst of map.values()) {
-      if(inst.disconnectedCallback) {
+    map.forEach(function(inst) {
+      if (inst.disconnectedCallback) {
         inst.disconnectedCallback();
       }
-    }
+    }, this);
 
     this._elementMap.delete(element);
   }

--- a/registry.js
+++ b/registry.js
@@ -61,9 +61,11 @@ class CustomAttributeRegistry {
     document = document || this.ownerDocument;
 
     var matches = document.querySelectorAll("[" + attrName + "]");
-    for(var match of matches) {
+
+    // Use a forEach as Edge doesn't support for...of on a NodeList
+    forEach.call(matches, function(match) {
       this._found(attrName, match);
-    }
+    }, this);
   }
 
   _upgradeElement(element) {
@@ -75,7 +77,6 @@ class CustomAttributeRegistry {
         this._found(attr.name, element);
       }
     }, this);
-
 
     for(var attr of this._attrMap.keys()) {
       this._upgradeAttr(attr, element);


### PR DESCRIPTION
This tweaks the usage of `Map` and also remove `for...of` iterators to support IE11 and Edge. Edge / IE doesn't support `for...of` on a `NodeList` and IE11 doesn't support `values` / `keys` on `Map`, only `forEach`.